### PR TITLE
Workaround of unactive pinned apps showing as active

### DIFF
--- a/windowlist@cobinja.de/applet.js
+++ b/windowlist@cobinja.de/applet.js
@@ -871,6 +871,12 @@ CobiAppButton.prototype = {
       text += number;
     }
     this._labelNumber.set_text(text);
+    if (number == 0){
+        this.actor.set_style_class_name("app-list-item-box");
+    }
+    else {
+        this.actor.set_style_class_name("window-list-item-box"); 
+    }
   },
   
   _updateLabel: function(actor, event) {


### PR DESCRIPTION
Workaround of unactive pinned apps showing as active windows.
(Dunno how is, but it works only if any app has been opened once)