### PR TITLE
Add option: close all windows w/ middle mouse button

### DIFF
--- a/windowlist@cobinja.de/3.2/applet.js
+++ b/windowlist@cobinja.de/3.2/applet.js
@@ -1171,7 +1171,10 @@ CobiAppButton.prototype = {
     }
     // left mouse button
     if (event.get_state() & Clutter.ModifierType.BUTTON1_MASK) {
-      if (this._currentWindow) {
+      if (this._settings.getValue("icon-close-on-middle-click") && event.get_state() & Clutter.ModifierType.SHIFT_MASK) {
+        this._startApp();
+      }
+      else if (this._currentWindow) {
         if (this._windows.length == 1 || !(this._settings.getValue("menu-show-on-click"))) {
           if (_hasFocus(this._currentWindow)) {
             this._currentWindow.minimize();
@@ -1190,7 +1193,13 @@ CobiAppButton.prototype = {
     }
     // middle mouse button
     else if (event.get_state() & Clutter.ModifierType.BUTTON2_MASK) {
-      this._startApp();
+      if (!this._settings.getValue("icon-close-on-middle-click")) {
+        this._startApp();
+      } else {
+        for (let i = this._windows.length - 1; i >= 0; i--) {
+          this._windows[i].delete(global.get_current_time());
+        }
+      }
     }
     // right mouse button
     else if (event.get_state() & Clutter.ModifierType.BUTTON3_MASK) {

--- a/windowlist@cobinja.de/3.2/applet.js
+++ b/windowlist@cobinja.de/3.2/applet.js
@@ -67,6 +67,11 @@ const CobiDisplayNumber = {
   Smart: 2
 }
 
+const CobiIconMouseBinding = {
+  MiddleNewWindow: 0,
+  MiddleCloseAll: 1
+};
+
 Gettext.bindtextdomain(UUID, GLib.get_home_dir() + "/.local/share/locale");
 
 function _(text) {
@@ -1162,6 +1167,9 @@ CobiAppButton.prototype = {
   },
   
   _onButtonRelease: function(actor, event) {
+    const mouseBiding = this._settings.getValue("icon-mouse-binding");
+    const eventState = event.get_state();
+
     this.menu.removeDelay();
     if (this._contextMenu.isOpen) {
       this._contextMenu.close();
@@ -1170,8 +1178,8 @@ CobiAppButton.prototype = {
       this.menu.close();
     }
     // left mouse button
-    if (event.get_state() & Clutter.ModifierType.BUTTON1_MASK) {
-      if (this._settings.getValue("icon-close-on-middle-click") && event.get_state() & Clutter.ModifierType.SHIFT_MASK) {
+    if (eventState & Clutter.ModifierType.BUTTON1_MASK) {
+      if (mouseBiding === CobiIconMouseBinding.MiddleCloseAll && eventState & Clutter.ModifierType.SHIFT_MASK) {
         this._startApp();
       }
       else if (this._currentWindow) {
@@ -1192,8 +1200,8 @@ CobiAppButton.prototype = {
       }
     }
     // middle mouse button
-    else if (event.get_state() & Clutter.ModifierType.BUTTON2_MASK) {
-      if (!this._settings.getValue("icon-close-on-middle-click")) {
+    else if (eventState & Clutter.ModifierType.BUTTON2_MASK) {
+      if (mouseBiding === CobiIconMouseBinding.MiddleNewWindow) {
         this._startApp();
       } else {
         for (let i = this._windows.length - 1; i >= 0; i--) {
@@ -1202,7 +1210,7 @@ CobiAppButton.prototype = {
       }
     }
     // right mouse button
-    else if (event.get_state() & Clutter.ModifierType.BUTTON3_MASK) {
+    else if (eventState & Clutter.ModifierType.BUTTON3_MASK) {
       // context menu
       this._populateContextMenu();
       this._contextMenu.open();

--- a/windowlist@cobinja.de/3.2/settings-schema.json
+++ b/windowlist@cobinja.de/3.2/settings-schema.json
@@ -88,6 +88,12 @@
     "description": "Only show windows on the same monitor",
     "tooltip": "If enabled, this applet instance only manages windows\nthat are displayed on the same monitor"
   },
+  "icon-close-on-middle-click": {
+    "type": "switch",
+    "default": false,
+    "description": "Close all windows on mouse-wheel click",
+    "tooltip": "Use shift+left mouse button to open new windows instead"
+  },
   "section3": {
     "type": "section",
     "description" : "Preview menu"

--- a/windowlist@cobinja.de/3.2/settings-schema.json
+++ b/windowlist@cobinja.de/3.2/settings-schema.json
@@ -88,11 +88,14 @@
     "description": "Only show windows on the same monitor",
     "tooltip": "If enabled, this applet instance only manages windows\nthat are displayed on the same monitor"
   },
-  "icon-close-on-middle-click": {
-    "type": "switch",
-    "default": false,
-    "description": "Close all windows on mouse-wheel click",
-    "tooltip": "Use shift+left mouse button to open new windows instead"
+  "icon-mouse-binding": {
+    "type": "combobox",
+    "default": 0,
+    "options": {
+      "middle click: new window": 0,
+      "middle click: close all | shift + left click: new window": 1
+    },
+    "description": "Choose mouse binding"
   },
   "section3": {
     "type": "section",

--- a/windowlist@cobinja.de/4.0/applet.js
+++ b/windowlist@cobinja.de/4.0/applet.js
@@ -1199,7 +1199,10 @@ class CobiAppButton {
     }
     // left mouse button
     if (event.get_state() & Clutter.ModifierType.BUTTON1_MASK) {
-      if (this._currentWindow) {
+      if (this._settings.getValue("icon-close-on-middle-click") && event.get_state() & Clutter.ModifierType.SHIFT_MASK) {
+        this._startApp();
+      }
+      else if (this._currentWindow) {
         if (this._windows.length == 1 || !(this._settings.getValue("menu-show-on-click"))) {
           if (hasFocus(this._currentWindow)) {
             this._currentWindow.minimize();

--- a/windowlist@cobinja.de/4.0/applet.js
+++ b/windowlist@cobinja.de/4.0/applet.js
@@ -69,6 +69,11 @@ const CobiDisplayNumber = {
   Smart: 2
 }
 
+const CobiIconMouseBinding = {
+  MiddleNewWindow: 0,
+  MiddleCloseAll: 1
+};
+
 Gettext.bindtextdomain(UUID, GLib.get_home_dir() + "/.local/share/locale");
 
 function _(text) {
@@ -1190,6 +1195,9 @@ class CobiAppButton {
   }
   
   _onButtonRelease(actor, event) {
+    const mouseBiding = this._settings.getValue("icon-mouse-binding");
+    const eventState = event.get_state();
+
     this.menu.removeDelay();
     if (this._contextMenu.isOpen) {
       this._contextMenu.close();
@@ -1198,8 +1206,8 @@ class CobiAppButton {
       this.menu.close();
     }
     // left mouse button
-    if (event.get_state() & Clutter.ModifierType.BUTTON1_MASK) {
-      if (this._settings.getValue("icon-close-on-middle-click") && event.get_state() & Clutter.ModifierType.SHIFT_MASK) {
+    if (eventState & Clutter.ModifierType.BUTTON1_MASK) {
+      if (mouseBiding === CobiIconMouseBinding.MiddleCloseAll && eventState & Clutter.ModifierType.SHIFT_MASK) {
         this._startApp();
       }
       else if (this._currentWindow) {
@@ -1220,8 +1228,8 @@ class CobiAppButton {
       }
     }
     // middle mouse button
-    else if (event.get_state() & Clutter.ModifierType.BUTTON2_MASK) {
-      if (!this._settings.getValue("icon-close-on-middle-click")) {
+    else if (eventState & Clutter.ModifierType.BUTTON2_MASK) {
+      if (mouseBiding === CobiIconMouseBinding.MiddleNewWindow) {
         this._startApp();
       } else {
         for (let i = this._windows.length - 1; i >= 0; i--) {
@@ -1230,7 +1238,7 @@ class CobiAppButton {
       }
     }
     // right mouse button
-    else if (event.get_state() & Clutter.ModifierType.BUTTON3_MASK) {
+    else if (eventState & Clutter.ModifierType.BUTTON3_MASK) {
       // context menu
       this._populateContextMenu();
       this._contextMenu.open();

--- a/windowlist@cobinja.de/4.0/applet.js
+++ b/windowlist@cobinja.de/4.0/applet.js
@@ -1218,7 +1218,13 @@ class CobiAppButton {
     }
     // middle mouse button
     else if (event.get_state() & Clutter.ModifierType.BUTTON2_MASK) {
-      this._startApp();
+      if (!this._settings.getValue("icon-close-on-middle-click")) {
+        this._startApp();
+      } else {
+        for (let i = this._windows.length - 1; i >= 0; i--) {
+          this._windows[i].delete(global.get_current_time());
+        }
+      }
     }
     // right mouse button
     else if (event.get_state() & Clutter.ModifierType.BUTTON3_MASK) {

--- a/windowlist@cobinja.de/4.0/settings-schema.json
+++ b/windowlist@cobinja.de/4.0/settings-schema.json
@@ -88,6 +88,12 @@
     "description": "Only show windows on the same monitor",
     "tooltip": "If enabled, this applet instance only manages windows\nthat are displayed on the same monitor"
   },
+  "icon-close-on-middle-click": {
+    "type": "switch",
+    "default": false,
+    "description": "Close all windows on mouse-wheel click",
+    "tooltip": "Use shift+left mouse button to open new windows instead"
+  },
   "section3": {
     "type": "section",
     "description" : "Preview menu"

--- a/windowlist@cobinja.de/4.0/settings-schema.json
+++ b/windowlist@cobinja.de/4.0/settings-schema.json
@@ -88,11 +88,14 @@
     "description": "Only show windows on the same monitor",
     "tooltip": "If enabled, this applet instance only manages windows\nthat are displayed on the same monitor"
   },
-  "icon-close-on-middle-click": {
-    "type": "switch",
-    "default": false,
-    "description": "Close all windows on mouse-wheel click",
-    "tooltip": "Use shift+left mouse button to open new windows instead"
+  "icon-mouse-binding": {
+    "type": "combobox",
+    "default": 0,
+    "options": {
+      "middle click: new window": 0,
+      "middle click: close all | shift + left click: new window": 1
+    },
+    "description": "Choose mouse binding"
   },
   "section3": {
     "type": "section",


### PR DESCRIPTION
If the new option is enabled, middle mouse button click (i.e. mouse wheel click) on icon (not window preview) will close all windows in the group. To open a new window (middle mouse button by default) use shift + left mouse button instead (the latter is the default binding in Windows 7 btw.).

Closes #24 